### PR TITLE
Introduce UUID provider

### DIFF
--- a/src/main/java/com/mentoring/todolist/domain/RandomUUIDProvider.java
+++ b/src/main/java/com/mentoring/todolist/domain/RandomUUIDProvider.java
@@ -1,0 +1,11 @@
+package com.mentoring.todolist.domain;
+
+import java.util.UUID;
+
+public class RandomUUIDProvider implements UUIDProvider {
+
+    @Override
+    public UUID uuid() {
+        return UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/mentoring/todolist/domain/UUIDProvider.java
+++ b/src/main/java/com/mentoring/todolist/domain/UUIDProvider.java
@@ -1,0 +1,7 @@
+package com.mentoring.todolist.domain;
+
+import java.util.UUID;
+
+public interface UUIDProvider {
+    UUID uuid();
+}

--- a/src/main/java/com/mentoring/todolist/domain/entity/TodoList.java
+++ b/src/main/java/com/mentoring/todolist/domain/entity/TodoList.java
@@ -2,14 +2,13 @@ package com.mentoring.todolist.domain.entity;
 
 import com.mentoring.todolist.domain.entity.TodoList.Task.Priority;
 import com.mentoring.todolist.domain.exception.InvalidTodoListFormatException;
+import lombok.Getter;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import lombok.Getter;
 
 @Getter
 public class TodoList {
@@ -30,8 +29,8 @@ public class TodoList {
         createdAt = ZonedDateTime.now();
     }
 
-    public void addTask(String name, Priority priority) {
-        Task task = new Task(name, priority);
+    public void addTask(UUID id, String name, Priority priority) {
+        Task task = new Task(id, name, priority);
 
         tasks.add(task);
     }
@@ -50,8 +49,8 @@ public class TodoList {
             LOW, HIGH
         }
 
-        public Task(String name, Priority priority) {
-            this.id = UUID.randomUUID();
+        public Task(UUID id, String name, Priority priority) {
+            this.id = id;
             this.name = name;
             this.priority = priority;
         }

--- a/src/main/java/com/mentoring/todolist/domain/entity/TodoList.java
+++ b/src/main/java/com/mentoring/todolist/domain/entity/TodoList.java
@@ -2,11 +2,13 @@ package com.mentoring.todolist.domain.entity;
 
 import com.mentoring.todolist.domain.entity.TodoList.Task.Priority;
 import com.mentoring.todolist.domain.exception.InvalidTodoListFormatException;
+
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import lombok.Getter;
 
 @Getter
@@ -16,14 +18,14 @@ public class TodoList {
     private final ZonedDateTime createdAt;
     private final List<Task> tasks = new ArrayList<>();
 
-    public TodoList(String name) {
-        id = UUID.randomUUID();
+    public TodoList(UUID id, String name) {
 
         // Constraint size, format
         if (name == null || name.isEmpty()) {
             throw InvalidTodoListFormatException.withName(name);
         }
 
+        this.id = id;
         this.name = name;
         createdAt = ZonedDateTime.now();
     }

--- a/src/main/java/com/mentoring/todolist/domain/usecase/CreateTodoList.java
+++ b/src/main/java/com/mentoring/todolist/domain/usecase/CreateTodoList.java
@@ -1,17 +1,23 @@
 package com.mentoring.todolist.domain.usecase;
 
+import com.mentoring.todolist.domain.UUIDProvider;
 import com.mentoring.todolist.domain.entity.TodoList;
 import com.mentoring.todolist.domain.repository.TodoListRepository;
 
 public class CreateTodoList {
+    private final UUIDProvider uuidProvider;
     private final TodoListRepository repository;
 
-    public CreateTodoList(TodoListRepository repository) {
+    public CreateTodoList(
+            UUIDProvider uuidProvider,
+            TodoListRepository repository
+    ) {
+        this.uuidProvider = uuidProvider;
         this.repository = repository;
     }
 
     public CreateTodoListOutput execute(CreateTodoListInput input) {
-        TodoList todoList = new TodoList(input.getName());
+        TodoList todoList = new TodoList(uuidProvider.uuid(), input.getName());
 
         repository.save(todoList);
 

--- a/src/main/java/com/mentoring/todolist/infrastructure/config/TodoListConfig.java
+++ b/src/main/java/com/mentoring/todolist/infrastructure/config/TodoListConfig.java
@@ -1,15 +1,17 @@
 package com.mentoring.todolist.infrastructure.config;
 
+import com.mentoring.todolist.domain.UUIDProvider;
 import com.mentoring.todolist.domain.repository.TodoListRepository;
 import com.mentoring.todolist.domain.usecase.CreateTodoList;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class TodoListConfig
-{
+public class TodoListConfig {
+
     @Bean
-    public CreateTodoList createTodoList(TodoListRepository todoListRepository) {
-        return new CreateTodoList(todoListRepository);
+    public CreateTodoList createTodoList(
+            UUIDProvider uuidProvider, TodoListRepository todoListRepository) {
+        return new CreateTodoList(uuidProvider, todoListRepository);
     }
 }

--- a/src/main/java/com/mentoring/todolist/infrastructure/config/UUIDProviderConfig.java
+++ b/src/main/java/com/mentoring/todolist/infrastructure/config/UUIDProviderConfig.java
@@ -1,0 +1,15 @@
+package com.mentoring.todolist.infrastructure.config;
+
+import com.mentoring.todolist.domain.RandomUUIDProvider;
+import com.mentoring.todolist.domain.UUIDProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UUIDProviderConfig {
+
+    @Bean
+    public UUIDProvider uuidProvider() {
+        return new RandomUUIDProvider();
+    }
+}

--- a/src/test/java/com/mentoring/todolist/domain/usecase/CreateTodoListTest.java
+++ b/src/test/java/com/mentoring/todolist/domain/usecase/CreateTodoListTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import com.mentoring.todolist.domain.UUIDProvider;
 import com.mentoring.todolist.domain.entity.TodoList;
 import com.mentoring.todolist.domain.repository.TodoListRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,11 +16,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
+import java.util.UUID;
+
 // TODO Create todo list use case Unit test
 public class CreateTodoListTest {
 
-    public static final String TODOLIST_SAMPLE_NAME = "TODOLIST_SAMPLE";
+    private static final String TODOLIST_SAMPLE_NAME = "TODOLIST_SAMPLE";
+    private static final UUID TODOLIST_UUID = UUID.randomUUID();
+
     private CreateTodoList createTodoListUseCase;
+
+    @Mock
+    private UUIDProvider uuidProvider;
 
     @Mock
     private TodoListRepository repository;
@@ -29,11 +38,13 @@ public class CreateTodoListTest {
     @BeforeEach
     public void setUp() {
         openMocks(this);
-        createTodoListUseCase = new CreateTodoList(repository);
+        createTodoListUseCase = new CreateTodoList(uuidProvider, repository);
     }
 
     @Test
     public void executeTest() {
+        when(uuidProvider.uuid()).thenReturn(TODOLIST_UUID);
+
         CreateTodoListInput todoListRequest = new CreateTodoListInput(TODOLIST_SAMPLE_NAME);
         CreateTodoListOutput todoListResponse = createTodoListUseCase.execute(todoListRequest);
 
@@ -44,7 +55,7 @@ public class CreateTodoListTest {
         assertEquals(todoListCaptorValue.getId(), todoListResponse.getId());
         assertEquals(todoListCaptorValue.getCreatedAt(), todoListResponse.getCreatedAt());
 
-        assertNotNull(todoListResponse.getId());
+        assertEquals(TODOLIST_UUID, todoListResponse.getId());
         assertNotNull(todoListResponse.getCreatedAt());
         assertEquals(TODOLIST_SAMPLE_NAME, todoListResponse.getName());
     }

--- a/src/test/java/com/mentoring/todolist/domain/usecase/CreateTodoListTest.java
+++ b/src/test/java/com/mentoring/todolist/domain/usecase/CreateTodoListTest.java
@@ -42,7 +42,22 @@ public class CreateTodoListTest {
     }
 
     @Test
-    public void executeTest() {
+    public void shouldSaveTodoList() {
+        when(uuidProvider.uuid()).thenReturn(TODOLIST_UUID);
+
+        CreateTodoListInput todoListRequest = new CreateTodoListInput(TODOLIST_SAMPLE_NAME);
+        createTodoListUseCase.execute(todoListRequest);
+
+        verify(repository).save(todoListCaptor.capture());
+        TodoList todoListCaptorValue = todoListCaptor.getValue();
+
+        assertEquals(TODOLIST_SAMPLE_NAME, todoListCaptorValue.getName());
+        assertEquals(TODOLIST_UUID, todoListCaptorValue.getId());
+        assertNotNull(todoListCaptorValue.getCreatedAt());
+    }
+
+    @Test
+    public void shouldReturnList() {
         when(uuidProvider.uuid()).thenReturn(TODOLIST_UUID);
 
         CreateTodoListInput todoListRequest = new CreateTodoListInput(TODOLIST_SAMPLE_NAME);
@@ -51,12 +66,9 @@ public class CreateTodoListTest {
         verify(repository).save(todoListCaptor.capture());
         TodoList todoListCaptorValue = todoListCaptor.getValue();
 
-        assertEquals(TODOLIST_SAMPLE_NAME, todoListCaptorValue.getName());
-        assertEquals(todoListCaptorValue.getId(), todoListResponse.getId());
-        assertEquals(todoListCaptorValue.getCreatedAt(), todoListResponse.getCreatedAt());
-
         assertEquals(TODOLIST_UUID, todoListResponse.getId());
-        assertNotNull(todoListResponse.getCreatedAt());
         assertEquals(TODOLIST_SAMPLE_NAME, todoListResponse.getName());
+        assertNotNull(todoListResponse.getCreatedAt());
+        assertEquals(todoListCaptorValue.getCreatedAt(), todoListResponse.getCreatedAt());
     }
 }


### PR DESCRIPTION
In order to enable testing the UUID assigned to a todo list:
* Add external UUID provider
* The task list id creation is moved from the entity to the use case

Ideally if the same approach is followed for `com.mentoring.todolist.domain.entity.TodoList#createdAt` and an external `Clock` is used then in `com.mentoring.todolist.domain.usecase.CreateTodoListTest`
* the arguments captor  could be removed
* the multiple asserts could be replaced with a single assert comparing 
  * instances of `TodoList` in `#shouldSaveTodoList` 
  * instances of `CreateTodoListOutput` in `#shouldReturnList`